### PR TITLE
Make tmate port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ To know which port was tmate binded, run:
 docker ps # this will show you the container id
 docker port <container id> 2222
 ```
+
+By default tmate-docker will bind inside the container on port 2222. This means that the ssh command that tmate will give you will include that port.
+Sometimes you want to run on a different port. To do that you need to set the PORT environment variable, this will be the one that tmate will bind to inside the container.
+For example:
+```
+docker run --priviledged -e PORT=443 -p 443:443 -t nicopace/tmate-docker
+```

--- a/tmate-slave.sh
+++ b/tmate-slave.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /tmate-slave
-./tmate-slave -p $PORT 2>&1
+./tmate-slave -p ${PORT?2222} 2>&1
 

--- a/tmate-slave.sh
+++ b/tmate-slave.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /tmate-slave
-./tmate-slave -p 2222 2>&1
+./tmate-slave -p $PORT 2>&1
 


### PR DESCRIPTION
It cannot be hardcoded, because you might need it to run on a different port.
You cannot rely on docker port mapping, because tmate will give you an ssh connection that includes the port within the container.
