### PR TITLE
Allow to change the advertised hostname.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ docker port <container id> 2222
 ```
 
 By default tmate-docker will bind inside the container on port 2222. This means that the ssh command that tmate will give you will include that port.
-Sometimes you want to run on a different port. To do that you need to set the PORT environment variable, this will be the one that tmate will bind to inside the container.
+Sometimes you want to run on a different port. To do that you need to set the ```PORT``` environment variable, this will be the one that tmate will bind to inside the container.
+
+In a similar manner, the advertised hostname to connect to can be
+changed with the ```HOST``` environment variable. By default, the docker
+container name is used.
+
 For example:
 ```
-docker run --priviledged -e PORT=443 -p 443:443 -t nicopace/tmate-docker
+docker run --privileged -e HOST=example.com -e PORT=443 -p 443:443 -t nicopace/tmate-docker
 ```

--- a/tmate-slave.sh
+++ b/tmate-slave.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 cd /tmate-slave
-./tmate-slave -p ${PORT?2222} 2>&1
-
+if [ -n "${HOST}" ]; then
+  hostopt="-h ${HOST}"
+fi
+./tmate-slave $hostopt -p ${PORT?2222} 2>&1


### PR DESCRIPTION
Usually, the hostname of the docker container is not the one to use for connecting to tmate. This allows to change the hostname displayed using another environment variable.
