### PR TITLE
Correct a typo that prevents a docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:0.9.13
-MANTAINER Nicolas Pace <nicolas.pace@unixono.com.ar>
+MAINTAINER Nicolas Pace <nicolas.pace@unixono.com.ar>
 
 # Set correct environment variables.
 ENV HOME /root


### PR DESCRIPTION
A simple fix, but Docker is buggered without it.
