### PR TITLE
Add /usr/local/lib to LD_LIBRARY_PATH

### DIFF
--- a/tmate-slave.sh
+++ b/tmate-slave.sh
@@ -3,4 +3,4 @@ cd /tmate-slave
 if [ -n "${HOST}" ]; then
   hostopt="-h ${HOST}"
 fi
-./tmate-slave $hostopt -p ${PORT?2222} 2>&1
+LD_LIBRARY_PATH=/usr/local/lib ./tmate-slave $hostopt -p ${PORT?2222} 2>&1


### PR DESCRIPTION
In order to fix the following issue

`./tmate-slave: error while loading shared libraries: libmsgpackc.so.2: cannot open shared object file: No such file or directory`

fixes issue #8 
